### PR TITLE
Fix: 의존성 배열에서 꼭 필요하지 않은 값 제거

### DIFF
--- a/src/components/Modal/ArrayModal/ArrayModal.tsx
+++ b/src/components/Modal/ArrayModal/ArrayModal.tsx
@@ -27,7 +27,7 @@ const ArrayModal: React.FC<ArrayModalProps> = ({
     if (selectedOption === null) {
       onOptionClick('latest');
     }
-  }, [selectedOption, onOptionClick]);
+  }, []);
 
   return (
     <StyledArrayModal

--- a/src/components/Modal/SharingModal/SharingModal.tsx
+++ b/src/components/Modal/SharingModal/SharingModal.tsx
@@ -110,7 +110,7 @@ export default function SharingModal({ closeModal, albumId }: Props) {
         console.error(error);
       }
     })();
-  }, [albumId]);
+  }, []);
 
   const handleDeleteSharedUserBtn = async (index: number) => {
     setDeleteSharedUserIsPending(true);

--- a/src/components/global/App.tsx
+++ b/src/components/global/App.tsx
@@ -35,7 +35,7 @@ export default function App({
         dispatch(deleteAuth());
       }
     });
-  }, [dispatch]);
+  }, []);
 
   return (
     <>

--- a/src/containers/privacy/Privacy.tsx
+++ b/src/containers/privacy/Privacy.tsx
@@ -25,7 +25,7 @@ export default function Privacy() {
         dispatch(setPrevPath('privacy'));
       };
     }
-  }, [prevPath, dispatch]);
+  }, []);
 
   return (
     <>

--- a/src/containers/terms/Terms.tsx
+++ b/src/containers/terms/Terms.tsx
@@ -25,7 +25,7 @@ export default function Terms() {
         dispatch(setPrevPath('terms'));
       };
     }
-  }, [prevPath, dispatch]);
+  }, []);
 
   return (
     <>

--- a/src/hooks/dialog/useEscDialog.ts
+++ b/src/hooks/dialog/useEscDialog.ts
@@ -9,5 +9,5 @@ export default function useEscDialog(closeDialog: () => void) {
     };
 
     window.addEventListener('keydown', escDialog);
-  }, [closeDialog]);
+  }, []);
 }

--- a/src/hooks/dialog/useOverlayClose.ts
+++ b/src/hooks/dialog/useOverlayClose.ts
@@ -17,7 +17,7 @@ const useOverlayClose = (
     return () => {
       dialog?.removeEventListener('click', handleOverlayClick);
     };
-  }, [dialogRef, closeFunction]);
+  }, []);
 };
 
 export default useOverlayClose;

--- a/src/hooks/useAlbumItemLayout.ts
+++ b/src/hooks/useAlbumItemLayout.ts
@@ -28,7 +28,7 @@ export default function useAlbumItemLayout(node: HTMLLIElement | null) {
     };
 
     setLayout();
-  }, [windowWidth, imgSize, node]);
+  }, [imgSize]);
 
   return { setImgSize, gridRowEnd };
 }


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
Fix/home-sharedAlbum -> main

### 변경 사항
- 불필요하게 useEffect가 여러번 실행되는 경우가 발생하여 의존성 배열에서 꼭 필요하지 않은 값 제거