### PR TITLE
Fix: 업로드시 사용하는 날씨, 감정 이모티콘 경로 변경 및 상세페이지 내 업로드시 리랜더링 기능 추가

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -5,7 +5,7 @@ import { AccordionWrapper } from '@/components/Accordion/StyledAccordion';
 
 interface AccordionProps {
   question: string;
-  answer: string;
+  answer: { path: string; name: string }[];
   selectedImages: string;
   setSelectedImages: (images: string) => void;
 }
@@ -17,7 +17,6 @@ function Accordion({
   setSelectedImages,
 }: AccordionProps) {
   const [isAccordionOpen, setIsAccordionOpen] = useState(false);
-  const answerArray = answer.split(',');
 
   const handleQuestionClick = () => {
     setIsAccordionOpen((prev) => !prev);
@@ -50,19 +49,19 @@ function Accordion({
         </div>
         {isAccordionOpen && (
           <div className="anw" id="answer">
-            {answerArray.map((imagePath, index) => (
+            {answer.map((image, index) => (
               <button
                 type="button"
                 key={index}
-                onClick={() => handleAnswerClick(imagePath.trim())}
+                onClick={() => handleAnswerClick(image.name)}
                 className={
-                  selectedImages.includes(imagePath.trim()) ? 'selected' : ''
+                  selectedImages.includes(image.name) ? 'selected' : ''
                 }
                 aria-label="Toggle Menu"
               >
                 <Image
                   className="btnImg"
-                  src={imagePath.trim()}
+                  src={image.path.trim()}
                   width={36}
                   height={36}
                   alt={`이미지 ${index}`}

--- a/src/components/Accordion/MultipleAccordion.tsx
+++ b/src/components/Accordion/MultipleAccordion.tsx
@@ -8,7 +8,7 @@ import {
 
 interface AccordionProps {
   question: string;
-  answer: string;
+  answer: string[];
   selectedAlbum: string[];
   setSelectedAlbum: (album: string[]) => void;
 }
@@ -20,7 +20,6 @@ function MultipleAccordion({
   setSelectedAlbum,
 }: AccordionProps) {
   const [isAccordionOpen, setIsAccordionOpen] = useState(false);
-  const answerArray = answer.split(',');
 
   const handleQuestionClick = () => {
     setIsAccordionOpen((prev) => !prev);
@@ -57,7 +56,7 @@ function MultipleAccordion({
         {isAccordionOpen && (
           <MultiAccordionWrapper>
             <div className="anw" id="multiAnswer">
-              {answerArray.map((item, index) => (
+              {answer.map((item, index) => (
                 <button
                   type="button"
                   disabled={item === '전체 보기' ? true : false}

--- a/src/components/EditFeed/EditFeedContents.tsx
+++ b/src/components/EditFeed/EditFeedContents.tsx
@@ -18,17 +18,8 @@ import {
 } from '@/hooks/useUpdateFeedList';
 import { deleteImg } from '@/utils/SDKUtils';
 
+import { AccordionData, AlbumIdData } from '@/components/Upload/model';
 import type { Feed, FeedToUpdate } from '@/types/feed';
-
-interface AccordionData {
-  question: string;
-  answer: string[];
-}
-
-interface AlbumIdData {
-  albumName: string;
-  docId: string;
-}
 
 export default function EditFeedContents({
   feedData,
@@ -275,7 +266,7 @@ export default function EditFeedContents({
                   <Accordion
                     key={index}
                     question={data.question}
-                    answer={data.answer.join(',')}
+                    answer={data.answer}
                     selectedImages={
                       data.question === '오늘의 날씨'
                         ? selectedWeatherImage

--- a/src/components/EditFeed/EditFeedContents.tsx
+++ b/src/components/EditFeed/EditFeedContents.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/hooks/useUpdateFeedList';
 import { deleteImg } from '@/utils/SDKUtils';
 
-import { AccordionData, AlbumIdData } from '@/components/Upload/model';
+import { AccordionDataType, AlbumIdData } from '@/components/Upload/model';
 import type { Feed, FeedToUpdate } from '@/types/feed';
 
 export default function EditFeedContents({
@@ -45,7 +45,7 @@ export default function EditFeedContents({
     feedData.emotionImage,
   );
   const [file, setFile] = useState<FileList | null>(null);
-  const [accordionData, setAccordionData] = useState<AccordionData[]>([]);
+  const [accordionData, setAccordionData] = useState<AccordionDataType>();
   const [albumIdData, setAlbumIdData] = useState<AlbumIdData[]>([]);
   const [inputCount, setInputCount] = useState(0);
   const [isPending, setIsPending] = useState(false);
@@ -253,32 +253,28 @@ export default function EditFeedContents({
                 </Styled.KakaoMapContainer>
               )}
               <Styled.AccordionContents>
-                {accordionData.slice(1, 2).map(() => (
-                  <MultipleAccordion
-                    key={0}
-                    question={accordionData[0].question}
-                    answer={accordionData[0].answer.join(',')}
-                    selectedAlbum={selectedAlbumList}
-                    setSelectedAlbum={setSelectedAlbumList}
-                  />
-                ))}
-                {accordionData.slice(1, 3).map((data, index) => (
-                  <Accordion
-                    key={index}
-                    question={data.question}
-                    answer={data.answer}
-                    selectedImages={
-                      data.question === '오늘의 날씨'
-                        ? selectedWeatherImage
-                        : selectedEmotionImage
-                    }
-                    setSelectedImages={
-                      data.question === '오늘의 날씨'
-                        ? setSelectedWeatherImage
-                        : setSelectedEmotionImage
-                    }
-                  />
-                ))}
+                {accordionData !== undefined && (
+                  <>
+                    <MultipleAccordion
+                      question={accordionData[0].question}
+                      answer={accordionData[0].answer}
+                      selectedAlbum={selectedAlbumList}
+                      setSelectedAlbum={setSelectedAlbumList}
+                    />
+                    <Accordion
+                      question={accordionData[1].question}
+                      answer={accordionData[1].answer}
+                      selectedImages={selectedWeatherImage}
+                      setSelectedImages={setSelectedWeatherImage}
+                    />
+                    <Accordion
+                      question={accordionData[2].question}
+                      answer={accordionData[2].answer}
+                      selectedImages={selectedEmotionImage}
+                      setSelectedImages={setSelectedEmotionImage}
+                    />
+                  </>
+                )}
               </Styled.AccordionContents>
             </Styled.SelectPart>
           </>

--- a/src/components/FeedItem/FeedItem.tsx
+++ b/src/components/FeedItem/FeedItem.tsx
@@ -79,7 +79,7 @@ function FeedItem({ feed }: { feed: Feed }, ref: ForwardedRef<HTMLLIElement>) {
                     width={36}
                     height={36}
                     className="emotion"
-                    src={feedData.emotionImage}
+                    src={`/images/${feedData.emotionImage}.svg`}
                     alt="오늘의 기분"
                   />
                 )}
@@ -88,7 +88,7 @@ function FeedItem({ feed }: { feed: Feed }, ref: ForwardedRef<HTMLLIElement>) {
                     width={36}
                     height={36}
                     className="weather"
-                    src={feedData.weatherImage}
+                    src={`/images/${feedData.weatherImage}.svg`}
                     alt="오늘의 날씨"
                   />
                 )}

--- a/src/components/Modal/ChangeAlbumModal/ChangeAlbumModal.tsx
+++ b/src/components/Modal/ChangeAlbumModal/ChangeAlbumModal.tsx
@@ -17,11 +17,6 @@ import { closeDialogOnClick } from '@/utils/dialog';
 
 import { Feed } from '@/types/feed';
 
-interface AccordionItemData {
-  question: string;
-  answer: string[];
-}
-
 interface AlbumIdData {
   albumName: string;
   docId: string;
@@ -62,21 +57,20 @@ export default function ChangeAlbumModal({
       }
     };
 
-    const SetAcoordionData = async () => {
+    const SetAccordionData = async () => {
       const result = await getAccordionData();
       setAlbumIdData(result.albumIdData || []);
     };
 
     setSavedAlbumData();
-    SetAcoordionData();
+    SetAccordionData();
   }, []);
 
   useEffect(() => {
     const fetchData = async () => {
       const result = await getAccordionData();
       setAlbumIdData(result.albumIdData || []);
-      const accordionData: AccordionItemData[] | null =
-        result.accordionData || null;
+      const accordionData = result.accordionData || null;
 
       if (accordionData) {
         setAnswerArray(accordionData[0].answer);

--- a/src/components/Upload/GetAccordionData.ts
+++ b/src/components/Upload/GetAccordionData.ts
@@ -9,6 +9,11 @@ import {
 import { appFireStore } from '@/firebase/config';
 import useAuthState from '@/hooks/auth/useAuthState';
 
+interface AlbumIdData {
+  albumName: string;
+  docId: string;
+}
+
 const GetAccordionData = () => {
   const { user } = useAuthState();
 
@@ -39,30 +44,25 @@ const GetAccordionData = () => {
       {
         question: '오늘의 날씨',
         answer: [
-          '/images/sunny.svg',
-          '/images/partly-sunny.svg',
-          '/images/cloudy.svg',
-          '/images/rainy.svg',
-          '/images/snowy.svg',
+          { path: '/images/sunny.svg', name: 'sunny' },
+          { path: '/images/partly-sunny.svg', name: 'partly-sunny' },
+          { path: '/images/cloudy.svg', name: 'cloudy' },
+          { path: '/images/rainy.svg', name: 'rainy' },
+          { path: '/images/snowy.svg', name: 'snowy' },
         ],
       },
       {
         question: '오늘의 기분',
         answer: [
-          '/images/excited.svg',
-          '/images/smiling.svg',
-          '/images/yummy.svg',
-          '/images/frowning.svg',
-          '/images/sad.svg',
-          '/images/angry.svg',
+          { path: '/images/excited.svg', name: 'excited' },
+          { path: '/images/smiling.svg', name: 'smiling' },
+          { path: '/images/yummy.svg', name: 'yummy' },
+          { path: '/images/frowning.svg', name: 'frowning' },
+          { path: '/images/sad.svg', name: 'sad' },
+          { path: '/images/angry.svg', name: 'angry' },
         ],
       },
     ];
-
-    interface AlbumIdData {
-      albumName: string;
-      docId: string;
-    }
 
     const albumIdData: AlbumIdData[] = [];
 

--- a/src/components/Upload/GetAccordionData.ts
+++ b/src/components/Upload/GetAccordionData.ts
@@ -9,6 +9,7 @@ import {
 import { appFireStore } from '@/firebase/config';
 import useAuthState from '@/hooks/auth/useAuthState';
 
+import { AccordionDataType } from '@/components/Upload/model';
 interface AlbumIdData {
   albumName: string;
   docId: string;
@@ -36,7 +37,7 @@ const GetAccordionData = () => {
       console.log(error);
     }
 
-    const accordionData = [
+    const accordionData: AccordionDataType = [
       {
         question: '앨범 선택',
         answer: [],

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -259,7 +259,7 @@ function UploadModal() {
                       <Accordion
                         key={index}
                         question={data.question}
-                        answer={data.answer.join(',')}
+                        answer={data.answer}
                         selectedImages={
                           data.question === '오늘의 날씨'
                             ? selectedWeatherImage

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -21,7 +21,7 @@ import { useAddFeedIdFromFeedList } from '@/hooks/useUpdateFeedList';
 import useUploadFeed from '@/hooks/useUploadFeed';
 import { closeUploadFeedModal } from '@/modules/uploadFeedModal';
 
-import { AccordionData, AlbumIdData } from '@/components/Upload/model';
+import { AccordionDataType, AlbumIdData } from '@/components/Upload/model';
 
 function UploadModal() {
   const dispatch = useDispatch();
@@ -39,7 +39,7 @@ function UploadModal() {
   const [selectedEmotionImage, setSelectedEmotionImage] = useState<string>('');
   const [selectedAlbum, setSelectedAlbum] = useState<string[]>(albumNameToAdd);
   const [file, setFile] = useState<FileList | null>(null);
-  const [accordionData, setAccordionData] = useState<AccordionData[]>([]);
+  const [accordionData, setAccordionData] = useState<AccordionDataType>();
   const [albumIdData, setAlbumIdData] = useState<AlbumIdData[]>([]);
   const [isPending, setIsPending] = useState(false);
   const getAccordionData = GetAccordionData();
@@ -246,32 +246,28 @@ function UploadModal() {
                     </Styled.KakaoMapContainer>
                   )}
                   <Styled.AccordionContents>
-                    {accordionData.slice(1, 2).map(() => (
-                      <MultipleAccordion
-                        key={0}
-                        question={accordionData[0].question}
-                        answer={accordionData[0].answer.join(',')}
-                        selectedAlbum={selectedAlbum}
-                        setSelectedAlbum={setSelectedAlbum}
-                      />
-                    ))}
-                    {accordionData.slice(1, 3).map((data, index) => (
-                      <Accordion
-                        key={index}
-                        question={data.question}
-                        answer={data.answer}
-                        selectedImages={
-                          data.question === '오늘의 날씨'
-                            ? selectedWeatherImage
-                            : selectedEmotionImage
-                        }
-                        setSelectedImages={
-                          data.question === '오늘의 날씨'
-                            ? setSelectedWeatherImage
-                            : setSelectedEmotionImage
-                        }
-                      />
-                    ))}
+                    {accordionData !== undefined && (
+                      <>
+                        <MultipleAccordion
+                          question={accordionData[0].question}
+                          answer={accordionData[0].answer}
+                          selectedAlbum={selectedAlbum}
+                          setSelectedAlbum={setSelectedAlbum}
+                        />
+                        <Accordion
+                          question={accordionData[1].question}
+                          answer={accordionData[1].answer}
+                          selectedImages={selectedWeatherImage}
+                          setSelectedImages={setSelectedWeatherImage}
+                        />
+                        <Accordion
+                          question={accordionData[2].question}
+                          answer={accordionData[2].answer}
+                          selectedImages={selectedEmotionImage}
+                          setSelectedImages={setSelectedEmotionImage}
+                        />
+                      </>
+                    )}
                   </Styled.AccordionContents>
                 </Styled.SelectPart>
               </>

--- a/src/components/Upload/model.ts
+++ b/src/components/Upload/model.ts
@@ -1,11 +1,20 @@
-interface AccordionData {
-  question: string;
-  answer: { path: string; name: string }[];
-}
+// interface AccordionEmoticonData {
+//   question: string;
+//   answer: { path: string; name: string }[];
+// }
 
 interface AlbumIdData {
   albumName: string;
   docId: string;
 }
 
-export type { AccordionData, AlbumIdData };
+type AccordionDataType = [
+  {
+    question: '앨범 선택';
+    answer: string[];
+  },
+  { question: '오늘의 날씨'; answer: { path: string; name: string }[] },
+  { question: '오늘의 기분'; answer: { path: string; name: string }[] },
+];
+
+export type { AlbumIdData, AccordionDataType };

--- a/src/components/Upload/model.ts
+++ b/src/components/Upload/model.ts
@@ -1,6 +1,6 @@
 interface AccordionData {
   question: string;
-  answer: string[];
+  answer: { path: string; name: string }[];
 }
 
 interface AlbumIdData {

--- a/src/modules/model.ts
+++ b/src/modules/model.ts
@@ -62,6 +62,7 @@ type AuthAction =
 interface UploadFeedModalState {
   isUploadFeedModalOpen: boolean;
   albumNameToAdd: string[];
+  shouldUpdateFeedsData: boolean;
 }
 
 type UploadFeedModalAction =
@@ -69,9 +70,11 @@ type UploadFeedModalAction =
       type: 'open';
       payload: {
         albumNameToAdd: string[];
+        shouldUpdateFeedsData: false;
       };
     }
-  | { type: 'close'; payload: null };
+  | { type: 'close'; payload: null }
+  | { type: 'done'; payload: null };
 
 interface ReduxState {
   signup: SignupState;

--- a/src/modules/uploadFeedModal.ts
+++ b/src/modules/uploadFeedModal.ts
@@ -3,16 +3,24 @@ import { UploadFeedModalAction, UploadFeedModalState } from '@/modules/model';
 const initState = {
   isUploadFeedModalOpen: false,
   albumNameToAdd: [],
+  shouldUpdateFeedsData: false,
 };
 
 const openUploadFeedModal = (
   albumNameToAdd: string[],
 ): UploadFeedModalAction => {
-  return { type: 'open', payload: { albumNameToAdd } };
+  return {
+    type: 'open',
+    payload: { albumNameToAdd, shouldUpdateFeedsData: false },
+  };
 };
 
 const closeUploadFeedModal = (): UploadFeedModalAction => {
   return { type: 'close', payload: null };
+};
+
+const shouldReloadPostData = (): UploadFeedModalAction => {
+  return { type: 'done', payload: null };
 };
 
 const uploadFeedModalReducer = (
@@ -24,10 +32,12 @@ const uploadFeedModalReducer = (
       return { isUploadFeedModalOpen: true, ...action.payload };
     case 'close':
       return initState;
+    case 'done':
+      return { ...state, shouldUpdateFeedsData: true };
     default:
       return state;
   }
 };
 
 export default uploadFeedModalReducer;
-export { openUploadFeedModal, closeUploadFeedModal };
+export { openUploadFeedModal, closeUploadFeedModal, shouldReloadPostData };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 버그 수정

### 반영 브랜치
fix/upload -> main

### 변경 사항
- 상세페이지내에서 게시물 업로드시 리랜더링이 되지 않아 발생하는 문제를 해결하기 위해 => upload 리덕스에 상태 값 추가 (shouldReloadPostData)
- 게시물 업로드시 선택하는 날씨, 기분 기존에 path로 저장되는 형태 => 변수화 하여 단어로 저장하도록 수정 
