### PR TITLE
:bug: Fix: 이미지 svg 확장자 중 인식못하는 오류 해결(#49)

### DIFF
--- a/src/components/FileUpload/Preview.tsx
+++ b/src/components/FileUpload/Preview.tsx
@@ -20,7 +20,9 @@ const Preview = ({
     if (files && files.length > 0) {
       const file = files[0];
 
-      if (!/^image\/(jpg|svg|png|jpeg|gif|bmp|tif|heic)$/.test(file.type)) {
+      if (
+        !/^image\/(jpg|svg\+xml|png|jpeg|gif|bmp|tif|heic)$/.test(file.type)
+      ) {
         setSubmitErrMessage(
           '이미지 파일 확장자는 jpg, svg, png, jpeg, gif, bmp, tif, heic만 가능합니다.',
         );


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 버그 수정

### 반영 브랜치
Design/upload -> main

### 변경 사항
📍버그 발생 : 기존에 Preview 컴포넌트에서 이미지를 불러올 때 svg 파일임에도 예외처리되어 업로드 하지 못하는 오류 발생  
📍발생 이유 : 이미지 확장자 검사시  MIME 타입은 보통 `image/svg+xml`이어야 하지만 브라우저나 서버 설정에 따라 이 MIME 타입이 `image/svg`로 반환될 수도 있다고 함 => 정확한 MIME 타입을 반환하지 않는 경우, 위와 같은 오류 발생할 수 있다고 추측
📍해결 방법 :  SVG 파일의 MIME 타입을 svgl에서 svg+xml로 수정 => 무사 작동 완 👼🏻

