### PR TITLE
Fix: 홈피드 수정, 앨범 삭제, 수정시 state 상태값에 지정

### DIFF
--- a/src/components/Album/Album.tsx
+++ b/src/components/Album/Album.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { AlbumContainer, AlbumLink } from '@/components/Album/StyledAlbum';
 import AlbumMoreModal from '@/components/Modal/AlbumMoreModal';
-import DeleteAlbumModal from '@/components/Modal/DeleteAlbumModal/DeleteAlbumModal';
+import DeleteAndEditAlbumModal from '@/components/Modal/DeleteAndEditAlbumModal/DeleteAndEditAlbumModal';
 import SharingModal from '@/components/Modal/SharingModal/SharingModal';
 import useAuthState from '@/hooks/auth/useAuthState';
 
@@ -58,7 +58,7 @@ export default function Album({ albumData, showDeleteButton }: AlbumProps) {
               />
             )}
             {isEditAlbumModalOpen && (
-              <DeleteAlbumModal
+              <DeleteAndEditAlbumModal
                 albumId={album.id}
                 albumName={album.name}
                 onClose={() => setIsEditAlbumModalOpen(false)}

--- a/src/components/Album/Album.tsx
+++ b/src/components/Album/Album.tsx
@@ -1,22 +1,23 @@
 import { useState } from 'react';
 
-import { DocumentData } from 'firebase/firestore';
-
 import { AlbumContainer, AlbumLink } from '@/components/Album/StyledAlbum';
 import AlbumMoreModal from '@/components/Modal/AlbumMoreModal';
 import DeleteAlbumModal from '@/components/Modal/DeleteAlbumModal/DeleteAlbumModal';
 import SharingModal from '@/components/Modal/SharingModal/SharingModal';
 import useAuthState from '@/hooks/auth/useAuthState';
 
+import type { Album } from '@/types/album';
+
 interface AlbumProps {
-  albumData: DocumentData;
+  albumData: Album;
   showDeleteButton: boolean;
 }
 
-const Album = ({ albumData, showDeleteButton }: AlbumProps) => {
+export default function Album({ albumData, showDeleteButton }: AlbumProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isEditAlbumModalOpen, setIsEditAlbumModalOpen] = useState(false);
   const [isSharingModalOpen, setIsSharingModalOpen] = useState(false);
+  const [album, setAlbum] = useState<Album | null>(albumData);
 
   const { user } = useAuthState();
 
@@ -29,40 +30,52 @@ const Album = ({ albumData, showDeleteButton }: AlbumProps) => {
   };
 
   return (
-    <AlbumContainer $imageUrl={albumData.imageUrl}>
-      <AlbumLink href={`/${albumData.uid || user.uid}/album/${albumData.name}`}>
-        <div className="txtWrapper">
-          <p className="albumTitle">{albumData.name}</p>
-          <div className="CountWrapper">
-            <p className="albumCount">{albumData.feedList.length}</p>
-            {showDeleteButton && (
-              <button type="button" onClick={HandleModal} aria-label="더보기" />
-            )}
-          </div>
-        </div>
-      </AlbumLink>
+    <>
+      {album ? (
+        <li>
+          <AlbumContainer $imageUrl={album.imageUrl}>
+            <AlbumLink href={`/${album.uid || user.uid}/album/${album.name}`}>
+              <div className="txtWrapper">
+                <p className="albumTitle">{album.name}</p>
+                <div className="CountWrapper">
+                  <p className="albumCount">{album.feedList.length}</p>
+                  {showDeleteButton && (
+                    <button
+                      type="button"
+                      onClick={HandleModal}
+                      aria-label="더보기"
+                    />
+                  )}
+                </div>
+              </div>
+            </AlbumLink>
 
-      {isModalOpen && (
-        <AlbumMoreModal
-          closeModal={closeMoreModal}
-          setIsEditAlbumModalOpen={setIsEditAlbumModalOpen}
-          setIsSharingModalOpen={setIsSharingModalOpen}
-        />
+            {isModalOpen && (
+              <AlbumMoreModal
+                closeModal={closeMoreModal}
+                setIsEditAlbumModalOpen={setIsEditAlbumModalOpen}
+                setIsSharingModalOpen={setIsSharingModalOpen}
+              />
+            )}
+            {isEditAlbumModalOpen && (
+              <DeleteAlbumModal
+                albumId={album.id}
+                albumName={album.name}
+                onClose={() => setIsEditAlbumModalOpen(false)}
+                setAlbum={setAlbum}
+              />
+            )}
+            {isSharingModalOpen && (
+              <SharingModal
+                albumId={album.id}
+                closeModal={() => setIsSharingModalOpen(false)}
+              />
+            )}
+          </AlbumContainer>
+        </li>
+      ) : (
+        <></>
       )}
-      {isEditAlbumModalOpen && (
-        <DeleteAlbumModal
-          albumId={albumData.id}
-          albumName={albumData.name}
-          onClose={() => setIsEditAlbumModalOpen(false)}
-        />
-      )}
-      {isSharingModalOpen && (
-        <SharingModal
-          albumId={albumData.id}
-          closeModal={() => setIsSharingModalOpen(false)}
-        />
-      )}
-    </AlbumContainer>
+    </>
   );
-};
-export default Album;
+}

--- a/src/components/Modal/ArrayModal/ArrayModal.tsx
+++ b/src/components/Modal/ArrayModal/ArrayModal.tsx
@@ -6,7 +6,7 @@ import {
   Header,
 } from '@/components/Modal/ArrayModal/StyledArrayModal';
 import useEscDialog from '@/hooks/dialog/useEscDialog';
-import useShowModal from '@/hooks/dialog/useShowModal';
+import useShowNonModal from '@/hooks/dialog/useShowNonModal';
 import { closeDialogOnClick } from '@/utils/dialog';
 
 interface ArrayModalProps {
@@ -20,7 +20,7 @@ const ArrayModal: React.FC<ArrayModalProps> = ({
   selectedOption,
   onOptionClick,
 }) => {
-  const { showModal } = useShowModal();
+  const { showNonModal } = useShowNonModal();
   useEscDialog(onClose);
 
   useEffect(() => {
@@ -33,39 +33,51 @@ const ArrayModal: React.FC<ArrayModalProps> = ({
     <StyledArrayModal
       role="dialog"
       aria-labelledby="modal-select"
-      ref={showModal}
+      ref={showNonModal}
       onClick={(e) => closeDialogOnClick(e, onClose)}
     >
-      <Header className="modal-header" id="modal-select">
-        <h2>정렬기준</h2>
-      </Header>
-      <div className="modal-list">
-        <button
-          type="submit"
-          onClick={() => {
-            onOptionClick('latest');
-            onClose();
-          }}
-          className={selectedOption === 'latest' ? 'selected' : ''}
-        >
-          최신순
-          {selectedOption === 'latest' && (
-            <Image width={20} height={20} src="/icons/Select.svg" alt="선택" />
-          )}
-        </button>
-        <button
-          type="submit"
-          onClick={() => {
-            onOptionClick('oldest');
-            onClose();
-          }}
-          className={selectedOption === 'oldest' ? 'selected' : ''}
-        >
-          오래된순
-          {selectedOption === 'oldest' && (
-            <Image width={20} height={20} src="/icons/Select.svg" alt="선택" />
-          )}
-        </button>
+      <div className="modal-wrap">
+        <Header className="modal-header" id="modal-select">
+          <h2>정렬기준</h2>
+        </Header>
+        <div className="modal-list">
+          <button
+            type="submit"
+            onClick={() => {
+              onOptionClick('latest');
+              onClose();
+            }}
+            className={selectedOption === 'latest' ? 'selected' : ''}
+          >
+            최신순
+            {selectedOption === 'latest' && (
+              <Image
+                width={20}
+                height={20}
+                src="/icons/Select.svg"
+                alt="선택"
+              />
+            )}
+          </button>
+          <button
+            type="submit"
+            onClick={() => {
+              onOptionClick('oldest');
+              onClose();
+            }}
+            className={selectedOption === 'oldest' ? 'selected' : ''}
+          >
+            오래된순
+            {selectedOption === 'oldest' && (
+              <Image
+                width={20}
+                height={20}
+                src="/icons/Select.svg"
+                alt="선택"
+              />
+            )}
+          </button>
+        </div>
       </div>
     </StyledArrayModal>
   );

--- a/src/components/Modal/ArrayModal/StyledArrayModal.ts
+++ b/src/components/Modal/ArrayModal/StyledArrayModal.ts
@@ -1,11 +1,20 @@
 import styled from 'styled-components';
 
 const StyledArrayModal = styled.dialog`
-  border-radius: 1rem;
-  background-color: var(--background-color);
-  border: 1px solid var(--gray-200);
-  width: 19.6rem;
-  font-size: var(--text-s);
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: none;
+
+  .modal-wrap {
+    margin: 205px 318px 0 auto;
+    border-radius: 1rem;
+    background-color: var(--background-color);
+    border: 1px solid var(--gray-200);
+    width: 19.6rem;
+    font-size: var(--text-s);
+  }
 
   .modal-list button {
     display: flex;

--- a/src/components/Modal/DeleteAlbumModal/DeleteAlbumModal.tsx
+++ b/src/components/Modal/DeleteAlbumModal/DeleteAlbumModal.tsx
@@ -49,7 +49,7 @@ export default function DeleteAlbumModal({
     } else {
       setAlbum((prev) => {
         if (prev) {
-          return { ...prev, albumName: editAlbumName };
+          return { ...prev, name: editAlbumName };
         } else {
           return prev;
         }

--- a/src/components/Modal/DeleteAndEditAlbumModal/DeleteAndEditAlbumModal.tsx
+++ b/src/components/Modal/DeleteAndEditAlbumModal/DeleteAndEditAlbumModal.tsx
@@ -5,9 +5,9 @@ import LoadingComponent from '@/components/Loading/LoadingComponent';
 import AlertModal from '@/components/Modal/AlertModal/AlertModal';
 import ConfirmModal from '@/components/Modal/ConfirmModal/ConfirmModal';
 import {
-  StyledDeleteAlbumDialog,
+  StyledDeleteAndEditAlbumDialog,
   Header,
-} from '@/components/Modal/DeleteAlbumModal/StyledDeleteAlbumModal';
+} from '@/components/Modal/DeleteAndEditAlbumModal/StyledDeleteAndEditAlbumModal';
 import useEscDialog from '@/hooks/dialog/useEscDialog';
 import useShowModal from '@/hooks/dialog/useShowModal';
 import useDeleteAlbum from '@/hooks/useDeleteAlbum';
@@ -16,19 +16,19 @@ import { closeDialogOnClick } from '@/utils/dialog';
 
 import type { Album } from '@/types/album';
 
-interface DeleteAlbumModalProps {
+interface DeleteAndEditAlbumModalProps {
   onClose: () => void;
   albumName: string;
   albumId: string;
   setAlbum: React.Dispatch<SetStateAction<Album | null>>;
 }
 
-export default function DeleteAlbumModal({
+export default function DeleteAndEditAlbumModal({
   onClose,
   albumName,
   albumId,
   setAlbum,
-}: DeleteAlbumModalProps) {
+}: DeleteAndEditAlbumModalProps) {
   const [editAlbumName, setEditAlbumName] = useState(albumName);
   const [errMessage, setErrMessage] = useState('');
   const [showConfirmModal, setShowConfirmModal] = useState(false);
@@ -83,7 +83,7 @@ export default function DeleteAlbumModal({
         <AlertModal message={'삭제를 실패하였습니다'} onClose={onClose} />
       ) : (
         <>
-          <StyledDeleteAlbumDialog
+          <StyledDeleteAndEditAlbumDialog
             role="dialog"
             aria-labelledby="modal-select"
             ref={showModal}
@@ -137,7 +137,7 @@ export default function DeleteAlbumModal({
                 <Image width={20} height={20} src="/icons/x.svg" alt="" />
               </button>
             </form>
-          </StyledDeleteAlbumDialog>
+          </StyledDeleteAndEditAlbumDialog>
           {showConfirmModal && (
             <ConfirmModal
               onClose={() => setShowConfirmModal(false)}

--- a/src/components/Modal/DeleteAndEditAlbumModal/StyledDeleteAndEditAlbumModal.ts
+++ b/src/components/Modal/DeleteAndEditAlbumModal/StyledDeleteAndEditAlbumModal.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const StyledDeleteAlbumDialog = styled.dialog`
+const StyledDeleteAndEditAlbumDialog = styled.dialog`
   background: var(--background-color);
   border-radius: 10px;
   width: 31.8rem;
@@ -84,4 +84,4 @@ const Header = styled.header`
   }
 `;
 
-export { StyledDeleteAlbumDialog, Header };
+export { StyledDeleteAndEditAlbumDialog, Header };

--- a/src/components/Modal/InputModal/StyledInputModal.ts
+++ b/src/components/Modal/InputModal/StyledInputModal.ts
@@ -51,6 +51,9 @@ const StyledInputModal = styled.dialog`
     color: var(--point-dark-400);
     border-left: 1px solid var(--gray-200);
   }
+  .btn-wrap button:disabled {
+    cursor: default;
+  }
 `;
 
 const Header = styled.header`

--- a/src/components/Modal/NewAlbumModal.tsx
+++ b/src/components/Modal/NewAlbumModal.tsx
@@ -11,22 +11,14 @@ interface NewAlbumModalProps {
 const NewAlbumModal = ({ onClose, setAlbumData }: NewAlbumModalProps) => {
   const [albumName, setAlbumName] = useState('');
   const [errMessage, setErrMessage] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(true);
   const validateAndAddAlbum = useAddAlbum();
 
   const handleAlbum = async () => {
-    if (isSubmitting) {
+    if (isDisabled) {
       return;
     }
-
-    setIsSubmitting(true);
-
     try {
-      if (albumName.trim().length < 1 || albumName.trim().length > 20) {
-        setErrMessage('1자에서 20자 사이로 입력해 주세요');
-        return;
-      }
-
       const result = await validateAndAddAlbum({ albumName });
       if (result.updateData) {
         setAlbumData((prevState) => [...prevState, result.updateData]);
@@ -38,10 +30,19 @@ const NewAlbumModal = ({ onClose, setAlbumData }: NewAlbumModalProps) => {
 
       onClose();
     } finally {
-      setIsSubmitting(false);
+      setIsDisabled(true);
     }
   };
 
+  const handleValidate = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value.trim().length < 1 || e.target.value.trim().length > 20) {
+      setIsDisabled(true);
+      setErrMessage('1~20자 사이로 입력해 주세요');
+    } else {
+      setErrMessage('');
+      setIsDisabled(false);
+    }
+  };
   return (
     <InputModal
       onClose={onClose}
@@ -58,14 +59,17 @@ const NewAlbumModal = ({ onClose, setAlbumData }: NewAlbumModalProps) => {
           type="text"
           placeholder="이름을 입력해주세요"
           value={albumName}
-          onChange={(e) => setAlbumName(e.target.value)}
+          onChange={(e) => {
+            setAlbumName(e.target.value);
+            handleValidate(e);
+          }}
         />
         {errMessage !== '' && <strong role="alert">*{errMessage}</strong>}
         <div className="btn-wrap">
           <button type="button" onClick={onClose}>
             취소
           </button>
-          <button type="submit" disabled={isSubmitting}>
+          <button type="submit" disabled={isDisabled}>
             저장
           </button>
         </div>

--- a/src/components/Modal/NewAlbumModal.tsx
+++ b/src/components/Modal/NewAlbumModal.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 
-import { DocumentData } from 'firebase/firestore';
-
 import InputModal from '@/components/Modal/InputModal/InputModal';
 import useAddAlbum from '@/hooks/useAddAlbum';
+
+import type { Album } from '@/types/album';
 interface NewAlbumModalProps {
   onClose: () => void;
-  setAlbumData: React.Dispatch<React.SetStateAction<DocumentData[]>>;
+  setAlbumData: React.Dispatch<React.SetStateAction<Album[]>>;
 }
 const NewAlbumModal = ({ onClose, setAlbumData }: NewAlbumModalProps) => {
   const [albumName, setAlbumName] = useState('');

--- a/src/components/Upload/UploadModal/UploadModal.tsx
+++ b/src/components/Upload/UploadModal/UploadModal.tsx
@@ -26,7 +26,7 @@ import {
 
 import { AccordionDataType, AlbumIdData } from '@/components/Upload/model';
 
-function UploadModal() {
+export default function UploadModal() {
   const dispatch = useDispatch();
   const router = useRouter();
   const path = usePathname();
@@ -300,5 +300,3 @@ function UploadModal() {
     </>
   );
 }
-
-export default UploadModal;

--- a/src/containers/home/Home.tsx
+++ b/src/containers/home/Home.tsx
@@ -138,7 +138,7 @@ export default function Home({ album }: { album: AlbumType[] }) {
                 (v, index) => {
                   return (
                     <Album
-                      key={v.id}
+                      key={`${v.name}-${index}`}
                       albumData={v}
                       showDeleteButton={index !== 0}
                     />

--- a/src/containers/home/Home.tsx
+++ b/src/containers/home/Home.tsx
@@ -3,8 +3,6 @@
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
-import { DocumentData } from 'firebase/firestore';
-
 import Album from '@/components/Album/Album';
 import StyledH2 from '@/components/CommonStyled/StyledH2';
 import ArrayModal from '@/components/Modal/ArrayModal/ArrayModal';
@@ -15,15 +13,17 @@ import { StyledMain, StyledHomeSection } from '@/containers/home/StyledHome';
 import useWindowWidth from '@/hooks/useWindowWidth';
 import { getSharedAlbums } from '@/services/album';
 
-export default function Home({ album }: { album: DocumentData[] }) {
+import type { Album as AlbumType } from '@/types/album';
+
+export default function Home({ album }: { album: AlbumType[] }) {
   const [selectedAlbumType, setSelectedAlbumType] = useState<
     '나의 앨범' | '공유 앨범'
   >('나의 앨범');
   const [isArrayModalOpen, setIsArrayModalOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [albumData, setAlbumData] = useState<DocumentData[]>(album);
-  const [sharedAlbums, setSharedAlbums] = useState<DocumentData[]>([]);
+  const [albumData, setAlbumData] = useState<AlbumType[]>(album);
+  const [sharedAlbums, setSharedAlbums] = useState<AlbumType[]>([]);
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -137,9 +137,11 @@ export default function Home({ album }: { album: DocumentData[] }) {
               {(selectedOption === 'oldest' ? albumData : latestAlbumList).map(
                 (v, index) => {
                   return (
-                    <li key={`${v.name}-${index}`}>
-                      <Album albumData={v} showDeleteButton={index !== 0} />
-                    </li>
+                    <Album
+                      key={v.id}
+                      albumData={v}
+                      showDeleteButton={index !== 0}
+                    />
                   );
                 },
               )}
@@ -151,9 +153,11 @@ export default function Home({ album }: { album: DocumentData[] }) {
                 : sharedAlbums.reverse()
               ).map((v, index) => {
                 return (
-                  <li key={v.createdTime}>
-                    <Album albumData={v} showDeleteButton={index !== 0} />
-                  </li>
+                  <Album
+                    key={v.id}
+                    albumData={v}
+                    showDeleteButton={index !== 0}
+                  />
                 );
               })}
             </ul>

--- a/src/hooks/useAddAlbum.ts
+++ b/src/hooks/useAddAlbum.ts
@@ -4,6 +4,8 @@ import { appFireStore } from '@/firebase/config';
 import useAuthState from '@/hooks/auth/useAuthState';
 import { addAlbum } from '@/utils/SDKUtils';
 
+import type { Album } from '@/types/album';
+
 interface Props {
   albumName: string;
 }
@@ -33,7 +35,7 @@ export default function useAddAlbum() {
       const querySnapshot = await getDocs(duplicateAlbumQuery);
       if (querySnapshot) {
         const doc = querySnapshot.docs[0];
-        const updateData = doc.data();
+        const updateData = doc.data() as Album;
         return { updateData: updateData, success: true };
       } else {
         return { updateData: null, success: true };

--- a/src/types/album.ts
+++ b/src/types/album.ts
@@ -1,0 +1,16 @@
+import { Timestamp } from 'firebase/firestore';
+
+interface AlbumMetadata {
+  feedList: [];
+  createdTime: Timestamp;
+  name: string;
+  sharedUsers?: [];
+}
+
+interface Album extends AlbumMetadata {
+  imageUrl: string;
+  id: string;
+  uid?: string;
+}
+
+export type { AlbumMetadata, Album };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 버그 수정
- [x] 스타일
- [x] 문서 수정

### 반영 브랜치
ex) Refactor/home -> main

### 변경 사항
 1. Album 타입지정 
 2. 앨범 삭제시 , 수정시 state 상태값에 넣어 기존에있는 prev에 수정 삭제 처리하였습니다.
 3. array모달 showNonModal로 교체 , 아직 위치조정은 안된상태입니다.
 4. 함수선언문을 export default Function으로 교체했습니다.
 5.  album컨포넌트 map 순환시 key값을 좀더 정밀하게 작성하였습니다.
 6. 앨범 등록시 기존에하던 form 양식제출시 하던 유효성 검사를 onChange시로 변경 즉시 유효성 검사실행 통과할시 에러메세지 안보이게 처리했습니다.
 7. 유효성검사를 통과못할시 마우스 커서 디폴트로 고정해두었습니다.
 8. 기존의 DeleteAlbumModal은 앨범 삭제와 수정이 같이있는 모달이였습니다 따라서 폴더와 파일명을 DeleteAndEditAlbumModal 로 변경하였습니다 