### PR TITLE
🐛 공유 앨범, 나의앨범 변경시 스크롤 유무에 따른 main컴포넌트 padding값 차감 

### DIFF
--- a/src/containers/home/Home.tsx
+++ b/src/containers/home/Home.tsx
@@ -26,7 +26,14 @@ export default function Home({ album }: { album: AlbumType[] | null }) {
   const [albumData, setAlbumData] = useState<AlbumType[]>(album || []);
   const [sharedAlbums, setSharedAlbums] = useState<AlbumType[]>([]);
   const [error, setError] = useState('');
-
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+  useEffect(() => {
+    const updateScrollbarWidth = () => {
+      const width = window.innerWidth - document.documentElement.clientWidth;
+      setScrollbarWidth(width);
+    };
+    updateScrollbarWidth();
+  }, [selectedAlbumType]);
   useEffect(() => {
     (async () => {
       try {
@@ -81,7 +88,7 @@ export default function Home({ album }: { album: AlbumType[] | null }) {
   return (
     <>
       {windowWidth && windowWidth <= 430 && <HomeTopbar />}
-      <StyledMain>
+      <StyledMain $scrollbarWidth={scrollbarWidth}>
         {(!album || error) && (
           <Toast message="데이터를 불러오는 중 에러가 발생했습니다" />
         )}

--- a/src/containers/home/StyledHome.ts
+++ b/src/containers/home/StyledHome.ts
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
+type MainProps = {
+  $scrollbarWidth: number;
+};
 
-const StyledMain = styled.main`
+const StyledMain = styled.main<MainProps>`
   position: relative;
   padding: 24px var(--margin-mobile) calc(var(--nav-height-mobile) + 40px);
 
@@ -11,7 +14,9 @@ const StyledMain = styled.main`
 
   @media (min-width: 1025px) {
     padding: 0 var(--margin-pc) 55px;
-    margin: var(--padding-top-pc) var(--right-padding-pc) 0 var(--nav-width-pc);
+    margin: var(--padding-top-pc)
+      calc(var(--right-padding-pc) - ${(props) => props.$scrollbarWidth}px) 0
+      var(--nav-width-pc);
   }
 `;
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가
- [x] 버그 수정
- [x] 스타일


### 반영 브랜치

ex)Refactor/home -> main

### 변경 사항

나의 앨범, 공유 앨범 이동간 스크롤 유무에 따른 x축 UI이동 현상이 있었습니다.
 selectedAlbumType 이 변경 될때마다 `window.innerWidth - document.documentElement.clientWidth;` 코드로 스크롤의 길이를 알수있었고 StyledMain의 props로 scrollbarWidth길이를 전달, StyledMain 오른쪽 padding값에 차감을 시켜줬습니다. 스크롤이 없을시 scrollbarWidth가 0 이 되므로 변동사항 없습니다.
