### PR TITLE
Fix : 게시물 업로드시 날씨 아이콘 선택 버그 수정

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -54,9 +54,7 @@ function Accordion({
                 type="button"
                 key={index}
                 onClick={() => handleAnswerClick(image.name)}
-                className={
-                  selectedImages.includes(image.name) ? 'selected' : ''
-                }
+                className={selectedImages === image.name ? 'selected' : ''}
                 aria-label="Toggle Menu"
               >
                 <Image

--- a/src/components/Upload/GetAccordionData.ts
+++ b/src/components/Upload/GetAccordionData.ts
@@ -42,7 +42,7 @@ const GetAccordionData = () => {
         question: '오늘의 날씨',
         answer: [
           { path: '/images/sunny.svg', name: 'sunny' },
-          { path: '/images/partly-sunny.svg', name: 'partly-Sunny' },
+          { path: '/images/partly-sunny.svg', name: 'partly-sunny' },
           { path: '/images/cloudy.svg', name: 'cloudy' },
           { path: '/images/rainy.svg', name: 'rainy' },
           { path: '/images/snowy.svg', name: 'snowy' },

--- a/src/components/Upload/GetAccordionData.ts
+++ b/src/components/Upload/GetAccordionData.ts
@@ -9,11 +9,7 @@ import {
 import { appFireStore } from '@/firebase/config';
 import useAuthState from '@/hooks/auth/useAuthState';
 
-import { AccordionDataType } from '@/components/Upload/model';
-interface AlbumIdData {
-  albumName: string;
-  docId: string;
-}
+import { AccordionDataType, AlbumIdData } from '@/components/Upload/model';
 
 const GetAccordionData = () => {
   const { user } = useAuthState();
@@ -46,7 +42,7 @@ const GetAccordionData = () => {
         question: '오늘의 날씨',
         answer: [
           { path: '/images/sunny.svg', name: 'sunny' },
-          { path: '/images/partly-sunny.svg', name: 'partly-sunny' },
+          { path: '/images/partly-sunny.svg', name: 'partly-Sunny' },
           { path: '/images/cloudy.svg', name: 'cloudy' },
           { path: '/images/rainy.svg', name: 'rainy' },
           { path: '/images/snowy.svg', name: 'snowy' },

--- a/src/components/Upload/model.ts
+++ b/src/components/Upload/model.ts
@@ -1,8 +1,3 @@
-// interface AccordionEmoticonData {
-//   question: string;
-//   answer: { path: string; name: string }[];
-// }
-
 interface AlbumIdData {
   albumName: string;
   docId: string;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 버그 수정

### 반영 브랜치

Fix/upload -> main

### 변경 사항

- 기존 날씨 선택 아이콘이 중복으로 선택되는 오류가 발생 
- sunny아이콘과 partly-sunny 아이콘의 구분을 위해 patly-Sunny로 수정